### PR TITLE
Fixes "FlowRouter is already initialized" error in production mode

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -2,4 +2,6 @@ import { FlowRouter } from 'meteor/meteorhacks:flow-router';
 
 import 'TodoApp/client';
 
-FlowRouter.initialize();
+Meteor.startup(function() {
+  FlowRouter.initialize();
+});


### PR DESCRIPTION
This change makes sure `FlowRouter.initialize()` runs after `FlowRouter.wait()`.

Please take a look.